### PR TITLE
Fixed actually running the integration tests.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -150,6 +150,11 @@ commands =
 basepython = python3
 skip_install = true
 deps =
+# We need an older pip, otherwise you get:
+# ImportError: cannot import name '_main' from 'pip.__main__'
+# See https://github.com/buildout/buildout/issues/567
+# We might even need pip==18.1, though this would surprise me.
+    pip==20.3.4
     setuptools >= 52
     zc.buildout >= 3.0.0a2
 commands_pre =

--- a/tox.ini
+++ b/tox.ini
@@ -35,10 +35,9 @@ deps =
 # extras =
 #     test
 
-[testenv:integration]
-# Integration tests: run only the tests of the test packages.
+# Paths for integration tests: run only the tests of the test packages.
 # Do not run plone.autoinclude tests.
-testpaths =
+integration_testpaths =
 # With --test-path=test-packages we find no tests.
 # Only paths to the src directories work.
     --test-path=test-packages/example.addon/src
@@ -50,8 +49,12 @@ testpaths =
     --test-path=test-packages/example.zopeaddon/src
     --test-path=test-packages/example.zopeintegration/src
     --test-path=test-packages/example.multipleeps/src
+
+[testenv:py{36,37,38,39,py3}-integration]
+# Integration tests: run only the tests of the test packages.
+# Do not run plone.autoinclude tests.
 commands =
-    zope-testrunner {[testenv:integration]testpaths} []
+    zope-testrunner {[testenv]integration_testpaths} []
 extras =
     test
 
@@ -87,7 +90,7 @@ deps =
     coverage-python-version
 commands =
     mkdir -p {toxinidir}/parts/htmlcov
-    coverage run -m zope.testrunner {[testenv:integration]testpaths} --test-path=src []
+    coverage run -m zope.testrunner {[testenv]integration_testpaths} --test-path=src []
     coverage html
     coverage report -m --fail-under=80
 


### PR DESCRIPTION
Adding a failing test had no effect at all.
Running the tests did not report any tests being run.

I noticed that for the unittest we had `[testenv:py{36,37,38,39,py3}-unit]` as tox.ini section name.
For integration it was simply `[testenv:integration]`.
When I switched the unittests to the simple spelling, no tests were running there either.
So I made the integration section name more difficult,
and added a new key `integration_testpaths` in the main testenv.
Now integration tests are run.