### PR TITLE
Test-only fix: pin exact pip version for buildout3.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -158,7 +158,7 @@ setenv =
 # Work around 'TypeError: dist must be a Distribution instance' on GHA:
     SETUPTOOLS_USE_DISTUTILS = stdlib
 deps =
-    pip >= 21.3.1
+    pip == 21.3.1
     setuptools >= 60.2.0
     zc.buildout >= 3.0.0rc1
 commands_pre =


### PR DESCRIPTION
zc.buildout 3.0.0rc1 does not work with pip 22+.

The [weekly tests failed](https://github.com/plone/plone.autoinclude/runs/5082194915?check_suite_focus=true).