### PR TITLE
Raise an exception when a module cannot be imported.

### DIFF
--- a/news/19.feature
+++ b/news/19.feature
@@ -1,0 +1,5 @@
+Raise an exception when a module cannot be imported.
+When environment variable ``AUTOINCLUDE_ALLOW_MODULE_NOT_FOUND_ERROR=1`` is set, we log an error and continue.
+See `issue 19 <https://github.com/plone/plone.autoinclude/issues/19>`_.
+[maurits]
+

--- a/src/plone/autoinclude/loader.py
+++ b/src/plone/autoinclude/loader.py
@@ -14,6 +14,10 @@ logger = logging.getLogger(__name__)
 
 # Dictionary of project names and packages that we have already imported.
 _known_module_names = {}
+# Maybe allow ModuleNotFoundError.
+AUTOINCLUDE_ALLOW_MODULE_NOT_FOUND_ERROR = bool(
+    int(os.getenv("AUTOINCLUDE_ALLOW_MODULE_NOT_FOUND_ERROR", 0))
+)
 
 
 def load_z3c_packages(target=""):
@@ -37,6 +41,15 @@ def load_z3c_packages(target=""):
             except ModuleNotFoundError:
                 # Note: this may happen a lot, at least for z3c.autoinclude,
                 # because the project name may not be the same as the package/module.
+                # If we accept it, we may hide real errors though:
+                # the module may be there but have an ImportError.
+                if not AUTOINCLUDE_ALLOW_MODULE_NOT_FOUND_ERROR:
+                    logger.error(
+                        f"Could not import {module_name}. Set environment variable "
+                        "AUTOINCLUDE_ALLOW_MODULE_NOT_FOUND_ERROR=1 if you want to "
+                        "allow this."
+                    )
+                    raise
                 logger.exception(f"Could not import {module_name}.")
                 _known_module_names[module_name] = None
                 continue


### PR DESCRIPTION
When environment variable `AUTOINCLUDE_ALLOW_MODULE_NOT_FOUND_ERROR=1` is set, we log an error and continue.
Fixes https://github.com/plone/plone.autoinclude/issues/19

Work in progress: the tests fail with this.