### PR TITLE
Fix wheel compatibility with older versions of setuptools and buildout.

### DIFF
--- a/news/34.bugfix
+++ b/news/34.bugfix
@@ -1,0 +1,2 @@
+Fix wheel compatibility with older versions of setuptools and buildout.
+[maurits]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[build-system]
+requires = ["setuptools==75.8.0"]
+
 [tool.towncrier]
 filename = "CHANGES.rst"
 directory = "news/"


### PR DESCRIPTION
See https://github.com/plone/plone.autoinclude/issues/34