### PR TITLE
Fix tests with buildout 4, and add tests with buildout 5.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,7 @@ jobs:
         - ["3.13", "py313-integration", "ubuntu-latest"]
         - ["3.9", "buildout", "ubuntu-latest"]
         - ["3.13", "buildout", "ubuntu-latest"]
+        - ["3.13", "buildout5", "ubuntu-latest"]
         - ["3.10", "coverage", "ubuntu-latest"]
 
     runs-on: ${{ matrix.config[2] }}

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -46,3 +46,7 @@ eggs =
     ExampleCamelCase
     namespaceexample.native
     namespaceexample.pkgutilns
+
+[versions]
+zc.recipe.testrunner = 3.2
+zc.recipe.egg = 3.0.0

--- a/buildout5.cfg
+++ b/buildout5.cfg
@@ -1,0 +1,6 @@
+[buildout]
+extends = buildout.cfg
+
+[versions]
+zc.recipe.testrunner = 4.0
+zc.recipe.egg = 4.0.0a1

--- a/news/+ec0e6475.tests.rst
+++ b/news/+ec0e6475.tests.rst
@@ -1,0 +1,3 @@
+Fix tests with buildout 4, and add tests with buildout 5.
+This is needed because we get more namespace packages.
+[maurits]

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
     lint
     py{39,310,311,312,313}-{integration,unit}
     buildout
+    buildout5
     coverage
 # Not enabled by default:
 # black
@@ -151,6 +152,20 @@ deps =
 commands_pre =
     python -m pip list
     {envbindir}/buildout -nc {toxinidir}/buildout.cfg buildout:directory={envdir}
+commands =
+    {envbindir}/test-unit {posargs:-cv}
+    {envbindir}/test-integration {posargs:-cv}
+
+[testenv:buildout5]
+basepython = python3
+skip_install = true
+deps =
+    pip == 25.2
+    setuptools == 80.9.0
+    zc.buildout == 5.0.0a2
+commands_pre =
+    python -m pip list
+    {envbindir}/buildout -nc {toxinidir}/buildout5.cfg buildout:directory={envdir}
 commands =
     {envbindir}/test-unit {posargs:-cv}
     {envbindir}/test-integration {posargs:-cv}


### PR DESCRIPTION
This is needed because we get more namespace packages. Error in the [scheduled test](https://github.com/plone/plone.autoinclude/actions/runs/17890615198/job/50870454923#step:5:97):

```
ModuleNotFoundError: No module named 'zc.recipe.testrunner'
```

